### PR TITLE
Update all Tauri dependencies to version 2.0 stable

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "stoqster",
-    "version": "1.1.3",
+    "version": "1.2.0",
     "productName": "Stoqster",
     "author": "Péter Blénessy",
     "private": true,
@@ -23,9 +23,9 @@
     "dependencies": {
         "@intlify/unplugin-vue-i18n": "^4.0.0",
         "@quasar/extras": "^1.12.5",
-        "@tauri-apps/api": "^2.0.0-rc.0",
-        "@tauri-apps/plugin-http": "~2.0.0-rc",
-        "@tauri-apps/plugin-updater": "~2.0.0-rc",
+        "@tauri-apps/api": "^2.0.0",
+        "@tauri-apps/plugin-http": "^2.0.0",
+        "@tauri-apps/plugin-updater": "^2.0.0",
         "core-js": "^3.21.0",
         "jszip": "^3.10.1",
         "localforage": "^1.10.0",
@@ -38,7 +38,7 @@
     },
     "devDependencies": {
         "@quasar/vite-plugin": "^1.7.0",
-        "@tauri-apps/cli": "^2.0.0-rc.17",
+        "@tauri-apps/cli": "^2.0.0",
         "@vitejs/plugin-vue": "^5.0.5",
         "sass": "^1.77.7",
         "vite": "^5.3.3"

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "stoqster"
-version = "0.1.1"
+version = "2.0.0"
 description = "A Tauri App"
 authors = ["Péter Blénessy"]
 edition = "2021"
@@ -9,18 +9,18 @@ rust-version = "1.60"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [build-dependencies]
-tauri-build = { version = "2.0.0-rc", features = [] }
+tauri-build = { version = "2.0.0", features = [] }
 
 [dependencies]
 serde_json = "1"
 serde = { version = "1.0", features = ["derive"] }
-tauri = { version = "2.0.0-rc", features = ["devtools"] }
-tauri-plugin-http = "2.0.0-rc"
-tauri-plugin-updater = "2.0.0-rc"
+tauri = { version = "2.0.0", features = ["devtools"] }
+tauri-plugin-http = "2.0.0"
+tauri-plugin-updater = "2.0.0"
 
 [lib]
 name = "stoqster_lib"
 crate-type = ["staticlib", "cdylib", "lib"]
 
 [target.'cfg(not(any(target_os = "android", target_os = "ios")))'.dependencies]
-tauri-plugin-updater = "2.0.0-rc"
+tauri-plugin-updater = "2.0.0"


### PR DESCRIPTION
Fixes #28

Updated dependencies to Tauri v2 stable

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/PeterBlenessy/stoqster/issues/28?shareId=11740780-4058-4106-b4c8-47d509df952f).